### PR TITLE
[GROW-82] Server 타임아웃 오류 처리

### DIFF
--- a/frontend/src/app/api/auth/google/callback/route.ts
+++ b/frontend/src/app/api/auth/google/callback/route.ts
@@ -1,4 +1,5 @@
 import {
+  fetchWithTimeout,
   getGoogleOAuth2Client,
   RESPONSE_STATUS,
   SERVICE_SERVER_URL,
@@ -31,11 +32,14 @@ export async function GET(req: Request) {
 
     let jwtResponse;
     try {
-      jwtResponse = await fetch(`${SERVICE_SERVER_URL}/api/auth/v1/google`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ id_token: idToken }),
-      });
+      jwtResponse = await fetchWithTimeout(
+        `${SERVICE_SERVER_URL}/api/auth/v1/google`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ id_token: idToken }),
+        },
+      );
     } catch (fetchError) {
       return NextResponse.json(
         { error: "서비스 서버와의 연결에서 문제가 발생했습니다." },

--- a/frontend/src/app/api/auth/google/callback/route.ts
+++ b/frontend/src/app/api/auth/google/callback/route.ts
@@ -1,60 +1,62 @@
 import {
   fetchWithTimeout,
   getGoogleOAuth2Client,
-  RESPONSE_STATUS,
   SERVICE_SERVER_URL,
 } from "@/shared";
 import setJWTCookie from "@/shared/utils/setJWTCookie";
 import { NextResponse } from "next/server";
 
 export async function GET(req: Request) {
-  const client = getGoogleOAuth2Client();
-  const requestUrl = new URL(req.url);
-  const authenticationCode = requestUrl.searchParams.get("code");
-
-  if (!authenticationCode) {
-    return NextResponse.json(
-      { error: "Google 계정 인증코드 발급이 실패했습니다." },
-      { status: RESPONSE_STATUS.BAD_REQUEST },
-    );
-  }
-
   try {
+    const client = getGoogleOAuth2Client();
+    const requestUrl = new URL(req.url);
+    const authenticationCode = requestUrl.searchParams.get("code");
+
+    if (!authenticationCode) {
+      throw new Error("Google 계정 인증코드가 없습니다.");
+      // return NextResponse.json(
+      //   { error: "Google 계정 인증코드 발급이 실패했습니다." },
+      //   { status: RESPONSE_STATUS.BAD_REQUEST },
+      // );
+    }
     const { tokens } = await client.getToken(authenticationCode);
     const idToken = tokens.id_token;
 
     if (!idToken) {
-      return NextResponse.json(
-        { error: "Google로부터 ID 토큰을 가져오는 작업을 실패했습니다." },
-        { status: RESPONSE_STATUS.INTERNAL_SERVER_ERROR },
-      );
+      throw new Error("Google로부터 ID 토큰을 가져오는 작업을 실패했습니다.");
+      // return NextResponse.json(
+      //   { error: "Google로부터 ID 토큰을 가져오는 작업을 실패했습니다." },
+      //   { status: RESPONSE_STATUS.INTERNAL_SERVER_ERROR },
+      // );
     }
 
     let jwtResponse;
-    try {
-      jwtResponse = await fetchWithTimeout(
-        `${SERVICE_SERVER_URL}/api/auth/v1/google`,
-        {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ id_token: idToken }),
-        },
+
+    jwtResponse = await fetchWithTimeout(
+      `${SERVICE_SERVER_URL}/api/auth/v1/google`,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ id_token: idToken }),
+      },
+    );
+
+    if (!jwtResponse.ok)
+      throw new Error(
+        `서비스 서버에서 오류가 발생했습니다.: ${await jwtResponse.text()}`,
       );
-    } catch (fetchError) {
-      return NextResponse.json(
-        { error: "서비스 서버와의 연결에서 문제가 발생했습니다." },
-        { status: RESPONSE_STATUS.INTERNAL_SERVER_ERROR },
-      );
-    }
 
     if (!jwtResponse.ok) {
-      const tokenResponseErrorText = await jwtResponse.text();
-      return NextResponse.json(
-        {
-          error: `서비스 서버에서 오류가 발생했습니다.: ${tokenResponseErrorText}`,
-        },
-        { status: jwtResponse.status },
+      throw new Error(
+        `서비스 서버에서 오류가 발생했습니다.: ${await jwtResponse.text()}`,
       );
+      // const tokenResponseErrorText = await jwtResponse.text();
+      // return NextResponse.json(
+      //   {
+      //     error: `서비스 서버에서 오류가 발생했습니다.: ${tokenResponseErrorText}`,
+      //   },
+      //   { status: jwtResponse.status },
+      // );
     }
 
     const jwtData = await jwtResponse.json();
@@ -62,9 +64,7 @@ export async function GET(req: Request) {
     const redirectUrl = new URL("/", requestUrl);
     return NextResponse.redirect(redirectUrl);
   } catch (error) {
-    return NextResponse.json(
-      { error: "Google 로그인이 알 수 없는 이유로 실패했습니다." },
-      { status: RESPONSE_STATUS.INTERNAL_SERVER_ERROR },
-    );
+    const redirectUrl = new URL("/?login=failed");
+    return NextResponse.redirect(redirectUrl);
   }
 }

--- a/frontend/src/app/api/auth/kakao/callback/route.ts
+++ b/frontend/src/app/api/auth/kakao/callback/route.ts
@@ -42,13 +42,16 @@ export async function GET(req: NextRequest) {
     );
 
     if (!idTokenResponse.ok) {
-      const idTokenErrorBody = await idTokenResponse.json();
-      return NextResponse.json(
-        {
-          error: `Kakao로부터 ID 토큰을 가져오는 작업이 실패했습니다: ${idTokenErrorBody.error_description || "알 수 없는 오류"}`,
-        },
-        { status: idTokenResponse.status },
+      throw new Error(
+        `Kakao로부터 ID 토큰을 가져오는 작업이 실패했습니다.: ${await idTokenResponse.text()}`,
       );
+      // const idTokenErrorBody = await idTokenResponse.json();
+      // return NextResponse.json(
+      //   {
+      //     error: `Kakao로부터 ID 토큰을 가져오는 작업이 실패했습니다: ${idTokenErrorBody.error_description || "알 수 없는 오류"}`,
+      //   },
+      //   { status: idTokenResponse.status },
+      // );
     }
 
     const idTokenData = await idTokenResponse.json();
@@ -64,13 +67,16 @@ export async function GET(req: NextRequest) {
     );
 
     if (!jwtResponse.ok) {
-      const jwtResponseErrorText = await jwtResponse.text();
-      return NextResponse.json(
-        {
-          error: `서비스 서버에서 오류가 발생했습니다.: ${jwtResponseErrorText || "알 수 없는 오류"}`,
-        },
-        { status: jwtResponse.status },
+      throw new Error(
+        `서비스 서버에서 오류가 발생했습니다.: ${await jwtResponse.text()}`,
       );
+      // const jwtResponseErrorText = await jwtResponse.text();
+      // return NextResponse.json(
+      //   {
+      //     error: `서비스 서버에서 오류가 발생했습니다.: ${jwtResponseErrorText || "알 수 없는 오류"}`,
+      //   },
+      //   { status: jwtResponse.status },
+      // );
     }
 
     const jwtData = await jwtResponse.json();
@@ -79,9 +85,8 @@ export async function GET(req: NextRequest) {
     const redirectUrl = new URL("/", requestUrl);
     return NextResponse.redirect(redirectUrl);
   } catch (error) {
-    return NextResponse.json(
-      { error: "Kakao 로그인이 알 수 없는 이유로 실패했습니다." },
-      { status: RESPONSE_STATUS.INTERNAL_SERVER_ERROR },
-    );
+    console.error(error);
+    const redirectUrl = new URL("/?login=failed");
+    return NextResponse.redirect(redirectUrl);
   }
 }

--- a/frontend/src/app/api/auth/naver/callback/route.ts
+++ b/frontend/src/app/api/auth/naver/callback/route.ts
@@ -47,13 +47,16 @@ export async function GET(req: NextRequest) {
     );
 
     if (!accessTokenResponse.ok) {
-      const accessTokenErrorBody = await accessTokenResponse.json();
-      return NextResponse.json(
-        {
-          error: `Naver로부터 액세스 토큰을 가져오는 작업이 실패했습니다: ${accessTokenErrorBody.error_description || "알 수 없는 오류"}`,
-        },
-        { status: accessTokenResponse.status },
+      throw new Error(
+        `Naver로부터 액세스 토큰을 가져오는 작업이 실패했습니다.: ${await accessTokenResponse.text()}`,
       );
+      // const accessTokenErrorBody = await accessTokenResponse.json();
+      // return NextResponse.json(
+      //   {
+      //     error: `Naver로부터 액세스 토큰을 가져오는 작업이 실패했습니다: ${accessTokenErrorBody.error_description || "알 수 없는 오류"}`,
+      //   },
+      //   { status: accessTokenResponse.status },
+      // );
     }
 
     const accessTokenData = await accessTokenResponse.json();
@@ -69,13 +72,16 @@ export async function GET(req: NextRequest) {
     );
 
     if (!jwtResponse.ok) {
-      const jwtResponseErrorText = await jwtResponse.text();
-      return NextResponse.json(
-        {
-          error: `서비스 서버에서 오류가 발생했습니다.: ${jwtResponseErrorText || "알 수 없는 오류"}`,
-        },
-        { status: jwtResponse.status },
+      throw new Error(
+        `서비스 서버에서 오류가 발생했습니다.: ${await jwtResponse.text()}`,
       );
+      // const jwtResponseErrorText = await jwtResponse.text();
+      // return NextResponse.json(
+      //   {
+      //     error: `서비스 서버에서 오류가 발생했습니다.: ${jwtResponseErrorText || "알 수 없는 오류"}`,
+      //   },
+      //   { status: jwtResponse.status },
+      // );
     }
 
     const jwtData = await jwtResponse.json();
@@ -84,9 +90,7 @@ export async function GET(req: NextRequest) {
     const redirectUrl = new URL("/", requestUrl);
     return NextResponse.redirect(redirectUrl);
   } catch (error) {
-    return NextResponse.json(
-      { error: "Naver 로그인이 알 수 없는 이유로 실패했습니다." },
-      { status: RESPONSE_STATUS.INTERNAL_SERVER_ERROR },
-    );
+    const redirectUrl = new URL("/?login=failed");
+    return NextResponse.redirect(redirectUrl);
   }
 }

--- a/frontend/src/app/api/auth/naver/callback/route.ts
+++ b/frontend/src/app/api/auth/naver/callback/route.ts
@@ -1,4 +1,9 @@
-import { RESPONSE_STATUS, SERVICE_SERVER_URL, setCookieForJWT } from "@/shared";
+import {
+  fetchWithTimeout,
+  RESPONSE_STATUS,
+  SERVICE_SERVER_URL,
+  setCookieForJWT,
+} from "@/shared";
 import { NextRequest, NextResponse } from "next/server";
 
 export async function GET(req: NextRequest) {
@@ -25,7 +30,7 @@ export async function GET(req: NextRequest) {
   }
 
   try {
-    const accessTokenResponse = await fetch(
+    const accessTokenResponse = await fetchWithTimeout(
       "https://nid.naver.com/oauth2.0/token",
       {
         method: "POST",
@@ -54,11 +59,14 @@ export async function GET(req: NextRequest) {
     const accessTokenData = await accessTokenResponse.json();
     const accessToken = accessTokenData.access_token;
 
-    const jwtResponse = await fetch(`${SERVICE_SERVER_URL}/api/auth/v1/naver`, {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ access_token: accessToken }),
-    });
+    const jwtResponse = await fetchWithTimeout(
+      `${SERVICE_SERVER_URL}/api/auth/v1/naver`,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ access_token: accessToken }),
+      },
+    );
 
     if (!jwtResponse.ok) {
       const jwtResponseErrorText = await jwtResponse.text();

--- a/frontend/src/app/api/auth/refresh/route.ts
+++ b/frontend/src/app/api/auth/refresh/route.ts
@@ -1,4 +1,9 @@
-import { RESPONSE_STATUS, SERVICE_SERVER_URL, setCookieForJWT } from "@/shared";
+import {
+  fetchWithTimeout,
+  RESPONSE_STATUS,
+  SERVICE_SERVER_URL,
+  setCookieForJWT,
+} from "@/shared";
 import { REFRESH_TOKEN } from "@/shared/constants/cookie";
 import { NextRequest, NextResponse } from "next/server";
 
@@ -11,7 +16,7 @@ export async function POST(req: NextRequest) {
         { status: RESPONSE_STATUS.BAD_REQUEST },
       );
     }
-    const refreshResponse = await fetch(
+    const refreshResponse = await fetchWithTimeout(
       `${SERVICE_SERVER_URL}/api/auth/v1/refresh`,
       {
         method: "POST",

--- a/frontend/src/entities/user/api/getUser.ts
+++ b/frontend/src/entities/user/api/getUser.ts
@@ -1,6 +1,8 @@
+import { fetchWithTimeout } from "@/shared";
+
 const getUser = async () => {
   try {
-    const res = await fetch("api/user", { method: "POST" });
+    const res = await fetchWithTimeout("api/user", { method: "POST" });
 
     if (!res.ok) {
       return null;

--- a/frontend/src/shared/index.ts
+++ b/frontend/src/shared/index.ts
@@ -29,3 +29,4 @@ export { default as PortfolioCarousel } from "./ui/PortfolioCarousel";
 export { getAccessToken, getRefreshToken } from "./utils/jwt-cookie";
 export { default as FloatingButton } from "./ui/FloatingButton";
 export { default as NoDataMessage } from "./ui/NoDataMessage";
+export { default as fetchWithTimeout } from "./utils/fetchWithTimeout";

--- a/frontend/src/shared/ui/PriceDisplay.tsx
+++ b/frontend/src/shared/ui/PriceDisplay.tsx
@@ -1,12 +1,13 @@
 // components/PriceDisplay.js
 export default function PriceDisplay({ price }) {
+  console.log(price);
   const formattedNumber = new Intl.NumberFormat("ko-KR", {
     style: "currency",
     currency: "KRW",
   }).format(price);
 
   return (
-    <div className="except-web:text-[24px] w-auto overflow-hidden text-ellipsis whitespace-nowrap font-semibold leading-[29px] except-mobile:text-[1.73vw]">
+    <div className="w-auto overflow-hidden text-ellipsis whitespace-nowrap font-semibold leading-[29px] except-mobile:text-[1.73vw] except-web:text-[24px]">
       {formattedNumber}
     </div>
   );

--- a/frontend/src/shared/utils/fetchWithTimeout.ts
+++ b/frontend/src/shared/utils/fetchWithTimeout.ts
@@ -1,0 +1,16 @@
+interface Options {
+  [key: string]: any;
+}
+
+const fetchWithTimeout = async (resource: string, options: Options = {}) => {
+  const { timeout = 5000, ...fetchOptions } = options;
+  const controller = new AbortController();
+  const id = setTimeout(() => controller.abort(), timeout);
+  const response = await fetch(resource, {
+    ...fetchOptions,
+    signal: controller.signal,
+  });
+  clearTimeout(id);
+  return response;
+};
+export default fetchWithTimeout;

--- a/frontend/src/widgets/Summary/api/fetchSampleSummary.ts
+++ b/frontend/src/widgets/Summary/api/fetchSampleSummary.ts
@@ -1,4 +1,4 @@
-import { SERVICE_SERVER_URL } from "@/shared";
+import { fetchWithTimeout, SERVICE_SERVER_URL } from "@/shared";
 export interface Summary {
   today_review_rate: number;
   total_asset_amount: number;
@@ -11,7 +11,7 @@ export interface Summary {
 
 const fetchSampleSummary = async (): Promise<Summary> => {
   try {
-    const response = await fetch(
+    const response = await fetchWithTimeout(
       `${SERVICE_SERVER_URL}/api/chart/v1/sample/summary`,
     );
     if (!response.ok) {

--- a/frontend/src/widgets/Summary/api/fetchSummary.ts
+++ b/frontend/src/widgets/Summary/api/fetchSummary.ts
@@ -1,4 +1,4 @@
-import { SERVICE_SERVER_URL } from "@/shared";
+import { fetchWithTimeout, SERVICE_SERVER_URL } from "@/shared";
 import { ACCESS_TOKEN } from "@/shared/constants/cookie";
 import { cookies } from "next/headers";
 export interface Summary {
@@ -13,13 +13,16 @@ export interface Summary {
 
 const fetchSummary = async (): Promise<Summary> => {
   try {
-    const response = await fetch(`${SERVICE_SERVER_URL}/api/chart/v1/summary`, {
-      method: "GET",
-      headers: {
-        "Content-Type": "application/json",
-        Authorization: "Bearer " + cookies().get(ACCESS_TOKEN)?.value,
+    const response = await fetchWithTimeout(
+      `${SERVICE_SERVER_URL}/api/chart/v1/summary`,
+      {
+        method: "GET",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: "Bearer " + cookies().get(ACCESS_TOKEN)?.value,
+        },
       },
-    });
+    );
     if (!response.ok) {
       throw new Error(`${response.status}: ${await response.json()}`);
     }

--- a/frontend/src/widgets/Summary/ui/Summary.tsx
+++ b/frontend/src/widgets/Summary/ui/Summary.tsx
@@ -15,6 +15,7 @@ export default async function Summary() {
   const summary = hasAccessToken
     ? await fetchSummary()
     : await fetchSampleSummary();
+  console.log(summary);
   return (
     <>
       <div className="flex w-full mobile:hidden except-mobile:space-x-[16px]">
@@ -22,8 +23,12 @@ export default async function Summary() {
           <SummaryCard
             key={i}
             title={SummaryTitle[item]}
-            amount={summary[item].profit_amount || summary[item]}
-            rate={summary[item].profit_rate || undefined}
+            amount={
+              summary[item].profit_amount || typeof summary[item] === "object"
+                ? 0
+                : summary[item]
+            }
+            rate={summary[item].profit_rate || 0}
           />
         ))}
       </div>

--- a/frontend/src/widgets/Summary/ui/SummaryCard.tsx
+++ b/frontend/src/widgets/Summary/ui/SummaryCard.tsx
@@ -14,8 +14,8 @@ export default function SummaryCard({ title, amount, rate }: SummaryCardProps) {
     <div className="w-1/4 mobile:w-full mobile:shrink-0">
       <Card title={title} height="100px">
         <div className="flex items-center">
-          {amount && title !== "오늘의 review" ? (
-            <PriceDisplay price={amount | 0} />
+          {title !== "오늘의 review" ? (
+            <PriceDisplay price={amount} />
           ) : (
             <div className="flex items-center space-x-[8px]">
               <p className="[1400px]:bg-red font-bold leading-[24px] except-mobile:text-[1.42vw] except-web:text-[20px]">
@@ -30,8 +30,9 @@ export default function SummaryCard({ title, amount, rate }: SummaryCardProps) {
               </span>
             </div>
           )}
-
-          {rate && <IncDecRate rate={rate} className={"ml-[16px]"} />}
+          {title === "수익금" && (
+            <IncDecRate rate={rate || 0} className={"ml-[16px]"} />
+          )}
         </div>
       </Card>
     </div>

--- a/frontend/src/widgets/daily-investment-tip/api/fetchTodayTip.ts
+++ b/frontend/src/widgets/daily-investment-tip/api/fetchTodayTip.ts
@@ -1,8 +1,10 @@
-import { SERVICE_SERVER_URL } from "@/shared";
+import { fetchWithTimeout, SERVICE_SERVER_URL } from "@/shared";
 
 const fetchTodayTip = async (): Promise<string> => {
   try {
-    const response = await fetch(`${SERVICE_SERVER_URL}/api/chart/v1/tip`);
+    const response = await fetchWithTimeout(
+      `${SERVICE_SERVER_URL}/api/chart/v1/tip`,
+    );
     if (!response.ok) {
       throw new Error(`${response.status}: ${await response.json()}`);
     }

--- a/frontend/src/widgets/estimate-dividend/api/fetchDummyEstimateDividend.ts
+++ b/frontend/src/widgets/estimate-dividend/api/fetchDummyEstimateDividend.ts
@@ -1,6 +1,7 @@
 import {
   DonutChartData,
   EstimateDividendAllData,
+  fetchWithTimeout,
   SERVICE_SERVER_URL,
 } from "@/shared";
 
@@ -8,7 +9,7 @@ const fetchDummyEstimateDividend = async (
   category: "every" | "type" = "every",
 ): Promise<EstimateDividendAllData | DonutChartData[]> => {
   try {
-    const response = await fetch(
+    const response = await fetchWithTimeout(
       `${SERVICE_SERVER_URL}/api/chart/v1/sample/estimate-dividend?category=${category}`,
     );
     if (!response.ok) {
@@ -19,6 +20,16 @@ const fetchDummyEstimateDividend = async (
     return estimateDividend;
   } catch (error) {
     console.error(error);
+    if (category === "every") {
+      return {
+        2024: {
+          xAxises: [],
+          data: [],
+          unit: "",
+          total: 0,
+        },
+      };
+    }
     return [];
   }
 };

--- a/frontend/src/widgets/estimate-dividend/api/fetchEstimateDividend.ts
+++ b/frontend/src/widgets/estimate-dividend/api/fetchEstimateDividend.ts
@@ -1,7 +1,7 @@
 import {
-  BarChartData,
   DonutChartData,
   EstimateDividendAllData,
+  fetchWithTimeout,
   SERVICE_SERVER_URL,
 } from "@/shared";
 import { ACCESS_TOKEN } from "@/shared/constants/cookie";
@@ -11,7 +11,7 @@ const fetchEstimateDividend = async (
   category: "every" | "type" = "every",
 ): Promise<EstimateDividendAllData | DonutChartData[]> => {
   try {
-    const response = await fetch(
+    const response = await fetchWithTimeout(
       `${SERVICE_SERVER_URL}/api/chart/v1/estimate-dividend?category=${category}`,
       {
         method: "GET",

--- a/frontend/src/widgets/estimate-dividend/ui/EstimateDividend.tsx
+++ b/frontend/src/widgets/estimate-dividend/ui/EstimateDividend.tsx
@@ -21,6 +21,7 @@ export default async function EstimateDividend() {
       ? fetchEstimateDividend("type")
       : fetchDummyEstimateDividend("type")) as Promise<DonutChartData[]>,
   ]);
+  console.log(estimatedDividendAll, estimatedDividendByStock);
   return (
     <EstimateDividendClient
       estimatedDividendAll={estimatedDividendAll}

--- a/frontend/src/widgets/estimate-dividend/ui/EstimateDividendClient.tsx
+++ b/frontend/src/widgets/estimate-dividend/ui/EstimateDividendClient.tsx
@@ -44,7 +44,7 @@ export default function EstimateDividendClient({
         </div>
       </div>
       {selectedTab === "모두" &&
-        estimatedDividendAll[barChartNavItems[currentNavItemIndex]].xAxises
+        estimatedDividendAll[barChartNavItems[currentNavItemIndex]]?.xAxises
           .length !== 0 && (
           <>
             <div className="mb-[16px] mt-[20px]">
@@ -80,7 +80,7 @@ export default function EstimateDividendClient({
         className={`${selectedTab === "모두" ? "h-[217px]" : "h-full"} w-full`}
       >
         {selectedTab === "모두" &&
-        estimatedDividendAll[barChartNavItems[currentNavItemIndex]].xAxises
+        estimatedDividendAll[barChartNavItems[currentNavItemIndex]]?.xAxises
           .length !== 0 ? (
           <BarChart
             chartData={

--- a/frontend/src/widgets/investment-performance-chart/api/fetchPerformanceAnalysis.ts
+++ b/frontend/src/widgets/investment-performance-chart/api/fetchPerformanceAnalysis.ts
@@ -1,4 +1,4 @@
-import { LineChartData, SERVICE_SERVER_URL } from "@/shared";
+import { fetchWithTimeout, LineChartData, SERVICE_SERVER_URL } from "@/shared";
 import { ACCESS_TOKEN } from "@/shared/constants/cookie";
 import { cookies } from "next/headers";
 export interface PerformanceAnalysisData {
@@ -17,7 +17,7 @@ const fetchPerformanceAnalysis = async (): Promise<PerformanceAnalysisData> => {
       sixMonthsResponse,
       oneYearResponse,
     ] = await Promise.all([
-      fetch(
+      fetchWithTimeout(
         `${SERVICE_SERVER_URL}/api/chart/v1/performance-analysis?interval=5day`,
         {
           method: "GET",
@@ -27,7 +27,7 @@ const fetchPerformanceAnalysis = async (): Promise<PerformanceAnalysisData> => {
           },
         },
       ),
-      fetch(
+      fetchWithTimeout(
         `${SERVICE_SERVER_URL}/api/chart/v1/performance-analysis?interval=1month`,
         {
           method: "GET",
@@ -37,7 +37,7 @@ const fetchPerformanceAnalysis = async (): Promise<PerformanceAnalysisData> => {
           },
         },
       ),
-      fetch(
+      fetchWithTimeout(
         `${SERVICE_SERVER_URL}/api/chart/v1/performance-analysis?interval=3month`,
         {
           method: "GET",
@@ -47,7 +47,7 @@ const fetchPerformanceAnalysis = async (): Promise<PerformanceAnalysisData> => {
           },
         },
       ),
-      fetch(
+      fetchWithTimeout(
         `${SERVICE_SERVER_URL}/api/chart/v1/performance-analysis?interval=6month`,
         {
           method: "GET",
@@ -57,7 +57,7 @@ const fetchPerformanceAnalysis = async (): Promise<PerformanceAnalysisData> => {
           },
         },
       ),
-      fetch(
+      fetchWithTimeout(
         `${SERVICE_SERVER_URL}/api/chart/v1/performance-analysis?interval=1year`,
         {
           method: "GET",

--- a/frontend/src/widgets/investment-performance-chart/api/fetchPerformanceSampleAnalysis.ts
+++ b/frontend/src/widgets/investment-performance-chart/api/fetchPerformanceSampleAnalysis.ts
@@ -1,4 +1,4 @@
-import { LineChartData, SERVICE_SERVER_URL } from "@/shared";
+import { fetchWithTimeout, LineChartData, SERVICE_SERVER_URL } from "@/shared";
 export interface PerformanceAnalysisData {
   fiveDayPerformanceData: LineChartData;
   monthlyPerformanceData: LineChartData;
@@ -16,19 +16,19 @@ const fetchPerformanceSampleAnalysis =
         sixMonthsResponse,
         oneYearResponse,
       ] = await Promise.all([
-        fetch(
+        fetchWithTimeout(
           `${SERVICE_SERVER_URL}/api/chart/v1/sample/performance-analysis?interval=5day`,
         ),
-        fetch(
+        fetchWithTimeout(
           `${SERVICE_SERVER_URL}/api/chart/v1/sample/performance-analysis?interval=1month`,
         ),
-        fetch(
+        fetchWithTimeout(
           `${SERVICE_SERVER_URL}/api/chart/v1/sample/performance-analysis?interval=3month`,
         ),
-        fetch(
+        fetchWithTimeout(
           `${SERVICE_SERVER_URL}/api/chart/v1/sample/performance-analysis?interval=6month`,
         ),
-        fetch(
+        fetchWithTimeout(
           `${SERVICE_SERVER_URL}/api/chart/v1/sample/performance-analysis?interval=1year`,
         ),
       ]);

--- a/frontend/src/widgets/market-index/api/fetchIndexes.ts
+++ b/frontend/src/widgets/market-index/api/fetchIndexes.ts
@@ -1,4 +1,4 @@
-import { SERVICE_SERVER_URL } from "@/shared";
+import { fetchWithTimeout, SERVICE_SERVER_URL } from "@/shared";
 export interface Indexes {
   name: string;
   name_kr: string;
@@ -7,7 +7,9 @@ export interface Indexes {
 }
 const fetchIndexes = async (): Promise<Indexes[]> => {
   try {
-    const response = await fetch(`${SERVICE_SERVER_URL}/api/chart/v1/indice`);
+    const response = await fetchWithTimeout(
+      `${SERVICE_SERVER_URL}/api/chart/v1/indice`,
+    );
     if (!response.ok) {
       throw new Error(`${response.status}: ${await response.json()}`);
     }

--- a/frontend/src/widgets/market-index/ui/MarketIndexes.tsx
+++ b/frontend/src/widgets/market-index/ui/MarketIndexes.tsx
@@ -18,10 +18,12 @@ export default async function MarketIndexes() {
   return (
     <div className="relative h-[95px] w-full items-center overflow-hidden rounded-md border border-gray-20 bg-gray-0 mobile:rounded-none mobile:border-none">
       <div className="flex h-full items-center px-[16px]">
-        {indexes ? (
+        {indexes.length !== 0 ? (
           <SwiperBox items={marketIndexItems} />
         ) : (
-          "주식 지수 정보를 가져오지 못했습니다."
+          <p className="flex w-full items-center justify-center text-sm">
+            주식 지수 정보를 가져오지 못했어요.
+          </p>
         )}
       </div>
     </div>

--- a/frontend/src/widgets/my-stocks/api/fetchDummyMyStocks.ts
+++ b/frontend/src/widgets/my-stocks/api/fetchDummyMyStocks.ts
@@ -1,9 +1,9 @@
-import { SERVICE_SERVER_URL } from "@/shared";
+import { fetchWithTimeout, SERVICE_SERVER_URL } from "@/shared";
 import { MyStock } from "./fetchMyStocks";
 
 const fetchDummyMyStocks = async (): Promise<MyStock[]> => {
   try {
-    const response = await fetch(
+    const response = await fetchWithTimeout(
       `${SERVICE_SERVER_URL}/api/chart/v1/sample/my-stock`,
     );
     if (!response.ok) {

--- a/frontend/src/widgets/my-stocks/api/fetchMyStocks.ts
+++ b/frontend/src/widgets/my-stocks/api/fetchMyStocks.ts
@@ -1,4 +1,4 @@
-import { SERVICE_SERVER_URL } from "@/shared";
+import { fetchWithTimeout, SERVICE_SERVER_URL } from "@/shared";
 import { ACCESS_TOKEN } from "@/shared/constants/cookie";
 import { cookies } from "next/headers";
 
@@ -12,7 +12,7 @@ export interface MyStock {
 
 const fetchMyStocks = async (): Promise<MyStock[]> => {
   try {
-    const response = await fetch(
+    const response = await fetchWithTimeout(
       `${SERVICE_SERVER_URL}/api/chart/v1/my-stock`,
       {
         method: "GET",

--- a/frontend/src/widgets/my-stocks/ui/MyStocks.tsx
+++ b/frontend/src/widgets/my-stocks/ui/MyStocks.tsx
@@ -16,12 +16,12 @@ export default async function MyStocks() {
     <div className="relative h-[390px] rounded-xl border border-gray-20 bg-white mobile:rounded-none mobile:border-none">
       <div className="flex items-center justify-between px-[16px] pb-[12px] pt-[16px]">
         <h3 className="text-heading-2">내 보유주식</h3>
-        {stocks[0].name !== "" && (
+        {stocks[0]?.name !== "" && stocks.length !== 0 && (
           <SeeMoreButton href={"/asset-management/sheet"} />
         )}
       </div>
       <div className="border-t border-gray-20">
-        {stocks[0].name === "" ? (
+        {stocks[0]?.name === "" || stocks.length === 0 ? (
           <NoDataMessage />
         ) : (
           <StockTable stocks={stocks} />

--- a/frontend/src/widgets/rich-portfolios/api/fetchRichPortfolio.ts
+++ b/frontend/src/widgets/rich-portfolios/api/fetchRichPortfolio.ts
@@ -1,11 +1,11 @@
-import { DonutChartData, SERVICE_SERVER_URL } from "@/shared";
+import { DonutChartData, fetchWithTimeout, SERVICE_SERVER_URL } from "@/shared";
 interface Portfolio {
   name: string;
   data: DonutChartData[];
 }
 const fetchRichPortfolio = async (): Promise<Portfolio[]> => {
   try {
-    const response = await fetch(
+    const response = await fetchWithTimeout(
       `${SERVICE_SERVER_URL}/api/chart/v1/rich-portfolio`,
     );
     if (!response.ok) {

--- a/frontend/src/widgets/stock-composition/api/fetchComposition.ts
+++ b/frontend/src/widgets/stock-composition/api/fetchComposition.ts
@@ -1,4 +1,4 @@
-import { DonutChartData, SERVICE_SERVER_URL } from "@/shared";
+import { DonutChartData, fetchWithTimeout, SERVICE_SERVER_URL } from "@/shared";
 import { ACCESS_TOKEN } from "@/shared/constants/cookie";
 import { cookies } from "next/headers";
 
@@ -6,7 +6,7 @@ const fetchComposition = async (
   type: "composition" | "account" = "composition",
 ): Promise<DonutChartData[]> => {
   try {
-    const response = await fetch(
+    const response = await fetchWithTimeout(
       `${SERVICE_SERVER_URL}/api/chart/v1/composition?type=${type}`,
       {
         method: "GET",

--- a/frontend/src/widgets/stock-composition/api/fetchDummyComposition.ts
+++ b/frontend/src/widgets/stock-composition/api/fetchDummyComposition.ts
@@ -1,10 +1,10 @@
-import { DonutChartData, SERVICE_SERVER_URL } from "@/shared";
+import { DonutChartData, fetchWithTimeout, SERVICE_SERVER_URL } from "@/shared";
 
 const fetchDummyComposition = async (
   type: "composition" | "account" = "composition",
 ): Promise<DonutChartData[]> => {
   try {
-    const response = await fetch(
+    const response = await fetchWithTimeout(
       `${SERVICE_SERVER_URL}/api/chart/v1/sample/composition?type=${type}`,
     );
     if (!response.ok) {

--- a/frontend/src/widgets/stock-composition/ui/StockCompositionClient.tsx
+++ b/frontend/src/widgets/stock-composition/ui/StockCompositionClient.tsx
@@ -19,6 +19,7 @@ export default function StockCompositionClient({
   useEffect(() => {
     setCurrentData(compositionData);
   }, [compositionData]);
+  console.log(currentData);
   return (
     <>
       <div className="mt-[16px] flex w-full except-mobile:absolute except-mobile:right-[16px] except-mobile:top-[12px] except-mobile:mt-0 except-mobile:w-[148px]">
@@ -32,7 +33,7 @@ export default function StockCompositionClient({
         </SegmentedButtonGroup>
       </div>
       <div className="mt-[48px] mobile:mt-[20px]">
-        {currentData[0]?.name === "자산 없음" || !currentData ? (
+        {currentData.length === 0 || currentData[0]?.name === "자산 없음" ? (
           <NoDataMessage />
         ) : (
           <DonutChart chartName="종목 구성" data={currentData} />


### PR DESCRIPTION
### 스크린샷
![screencapture-localhost-3000-2024-10-06-18_09_40](https://github.com/user-attachments/assets/f0a99bb0-f195-45cd-b64e-3244ca7de1c9)

### 작업 내용
- fetch() 커스텀 함수 작성: fetchWithTimeout()
  - 기본 타임아웃: 5초
- 홈 페이지 컴포넌트에서 데이터 패칭 오류 발생 시 NoDataMessage 컴포넌트가 정상적으로 렌더링되도록 수정
- 로그인 오류 시 NextResponse.redirect를 사용해 홈 페이지로 이동시키도록 수정 (기존: status를 400~500으로 반환하여 뷰포트에 오류 메시지가 그대로 노출되는 문제가 있었음)