### PR TITLE
[GROW-86] 부자들이 선택한 종목 TOP10 API 연동

### DIFF
--- a/frontend/src/shared/ui/IncDecRate.tsx
+++ b/frontend/src/shared/ui/IncDecRate.tsx
@@ -10,7 +10,7 @@ export default function IncDecRate({
   return (
     <div
       aria-label={`The rate is ${rate > 0 ? "increased" : rate < 0 ? "decreased" : "unchanged"} by ${rate}%`}
-      className={`flex h-[24px] w-[64px] items-center justify-center rounded-md px-[8px] py-[3px] text-body-4 ${rate === 0 ? "bg-gray-5 text-gray-50" : rate > 0 ? "bg-alert/10 text-alert" : "bg-decrease/10 text-decrease"} ${className}`}
+      className={`flex h-[24px] min-w-[64px] items-center justify-center rounded-md py-[3px] text-body-4 ${rate === 0 ? "bg-gray-5 text-gray-50" : rate > 0 ? "bg-alert/10 text-alert" : "bg-decrease/10 text-decrease"} ${className}`}
     >
       {rate > 0 && "+"}
       {roundedRate}%

--- a/frontend/src/widgets/top-10-selected-by-rich-person/api/fetchRichPicks.ts
+++ b/frontend/src/widgets/top-10-selected-by-rich-person/api/fetchRichPicks.ts
@@ -1,0 +1,22 @@
+import { fetchWithTimeout, SERVICE_SERVER_URL } from "@/shared";
+export interface RichPick {
+  name: string;
+  price: number;
+  rate: number;
+}
+const fetchRichPicks = async (): Promise<RichPick[]> => {
+  try {
+    const response = await fetchWithTimeout(
+      `${SERVICE_SERVER_URL}/api/chart/v1/rich-pick`,
+    );
+    if (!response.ok) {
+      throw new Error(`${response.status}: ${await response.json()}`);
+    }
+    return response.json();
+  } catch (error) {
+    console.error(error);
+    return [];
+  }
+};
+
+export default fetchRichPicks;

--- a/frontend/src/widgets/top-10-selected-by-rich-person/ui/Top10SelectedByRichPerson.tsx
+++ b/frontend/src/widgets/top-10-selected-by-rich-person/ui/Top10SelectedByRichPerson.tsx
@@ -1,25 +1,10 @@
-import { IncDecRate } from "@/shared";
 import Image from "next/image";
 import Top10SelectedByRichPersonItem from "./Top10SelectedByRichPersonItem";
+import fetchRichPicks from "../api/fetchRichPicks";
 
-const top10Stocks = [
-  {
-    rank: 1,
-    name: "최대 글자수-width130",
-    price: 111100000000,
-    rate: 11.29,
-  },
-  { rank: 2, name: "SK하이닉스", price: 183200, rate: 11.2 },
-  { rank: 3, name: "현대차", price: 27100, rate: 99.99 },
-  { rank: 4, name: "카카오", price: 49500, rate: 99.99 },
-  { rank: 5, name: "NAVER", price: 190100, rate: 99.99 },
-  { rank: 6, name: "삼성SDI", price: 412000, rate: 0.0 },
-  { rank: 7, name: "삼성전자", price: 156200, rate: -1.9 },
-  { rank: 8, name: "기아", price: 108900, rate: -0.09 },
-  { rank: 9, name: "LG전자", price: 95100, rate: -2.09 },
-  { rank: 10, name: "현대모비스", price: 245500, rate: -39.99 },
-];
-export default function Top10SelectedByRichPerson() {
+export default async function Top10SelectedByRichPerson() {
+  const top10Stocks = await fetchRichPicks();
+
   return (
     <div className="h-[592px] space-y-[16px] rounded-lg border border-gray-20 bg-white p-[16px] mobile:rounded-none mobile:border-none">
       <div className="flex items-center space-x-[8px]">
@@ -28,9 +13,9 @@ export default function Top10SelectedByRichPerson() {
       </div>
       <div>
         <ul>
-          {top10Stocks.map((stock) => (
-            <li key={stock.rank}>
-              <Top10SelectedByRichPersonItem stock={stock} />
+          {top10Stocks.map((stock, index) => (
+            <li key={index + 1}>
+              <Top10SelectedByRichPersonItem stock={stock} rank={index + 1} />
             </li>
           ))}
         </ul>

--- a/frontend/src/widgets/top-10-selected-by-rich-person/ui/Top10SelectedByRichPersonItem.tsx
+++ b/frontend/src/widgets/top-10-selected-by-rich-person/ui/Top10SelectedByRichPersonItem.tsx
@@ -1,25 +1,21 @@
 import { IncDecRate } from "@/shared";
 import Image from "next/image";
-
-interface Stock {
-  rank: number;
-  name: string;
-  price: number;
-  rate: number;
-}
+import { RichPick } from "../api/fetchRichPicks";
 
 export default function Top10SelectedByRichPersonItem({
   stock,
+  rank,
 }: {
-  stock: Stock;
+  stock: RichPick;
+  rank: number;
 }) {
   return (
     <div className="flex h-[52px] items-center justify-between px-[4px]">
       <div className="flex items-center space-x-[8px] overflow-hidden">
         <p
-          className={`${stock.rank < 4 && "text-green-60"} flex w-[2ch] shrink-0 items-center justify-center`}
+          className={`${rank < 4 && "text-green-60"} flex w-[2ch] shrink-0 items-center justify-center`}
         >
-          {stock.rank}
+          {rank}
         </p>
         <Image
           src="/images/stock_test_logo.svg"

--- a/frontend/src/widgets/top-10-selected-by-rich-person/ui/Top10SelectedByRichPersonItem.tsx
+++ b/frontend/src/widgets/top-10-selected-by-rich-person/ui/Top10SelectedByRichPersonItem.tsx
@@ -11,27 +11,25 @@ export default function Top10SelectedByRichPersonItem({
 }) {
   return (
     <div className="flex h-[52px] items-center justify-between px-[4px]">
-      <div className="flex items-center space-x-[8px] overflow-hidden">
+      <div className="flex w-fit shrink-0 items-center space-x-[8px] overflow-hidden pr-[8px]">
         <p
           className={`${rank < 4 && "text-green-60"} flex w-[2ch] shrink-0 items-center justify-center`}
         >
           {rank}
         </p>
-        <Image
-          src="/images/stock_test_logo.svg"
-          width={28}
-          height={28}
-          alt={stock.name}
-        />
-        <p className="block max-w-[94ch] truncate text-body-2 except-mobile:max-w-[108ch]">
+        <div className="relative h-[28px] w-[28px] shrink-0">
+          <Image src="/images/stock_test_logo.svg" fill alt={stock.name} />
+        </div>
+      </div>
+      <div className="flex w-full justify-between space-x-[16px] overflow-hidden pr-[12px]">
+        <p className="block w-full max-w-[128px] truncate text-body-2 except-mobile:max-w-[128px]">
           {stock.name}
         </p>
-      </div>
-
-      <div className="flex items-center space-x-[12px] overflow-hidden">
-        <p className="block items-center truncate text-body-3">
-          ₩{stock.price.toLocaleString("ko-KR")}
+        <p className="block max-w-[122px] items-center truncate text-body-3">
+          ₩{Number(stock.price.toFixed(0)).toLocaleString("ko-KR")}
         </p>
+      </div>
+      <div className="flex shrink-0 items-center overflow-hidden">
         <IncDecRate rate={stock.rate} />
       </div>
     </div>


### PR DESCRIPTION
## 스크린샷
![image](https://github.com/user-attachments/assets/f7874439-332c-47f8-82f3-32fa5e6f89c5)

## 작업 내용
- 부자들이 선택한 종목 TOP10 API 연동
- 부자들이 선택한 종목 TOP10 항목 타입 수정 (rank 필드 제거)
  - index를 기준으로 rank 유추
- 뷰포트 줄어들 때 name, price가 차지하는 너비가 항목 별로 다른 문제 수정
  - truncate한 요소의 부모요소에 overflow-hidden 적용
  - max-width 및 w-full 적용