### PR TITLE
GROW-87 feat: 요약 상단 페이지 상단 요약 컴포넌트 API 연동

### DIFF
--- a/frontend/src/app/QueryClientProvider.tsx
+++ b/frontend/src/app/QueryClientProvider.tsx
@@ -1,0 +1,16 @@
+"use client";
+
+import {
+  QueryClient,
+  QueryClientProvider as OriginQueryClientProvider,
+} from "@tanstack/react-query";
+import { PropsWithChildren } from "react";
+
+export default function QueryClientProvider({ children }: PropsWithChildren) {
+  const queryClient = new QueryClient();
+  return (
+    <OriginQueryClientProvider client={queryClient}>
+      {children}
+    </OriginQueryClientProvider>
+  );
+}

--- a/frontend/src/app/asset-management/layout.tsx
+++ b/frontend/src/app/asset-management/layout.tsx
@@ -1,6 +1,9 @@
 "use client"; // Client Component로 선언
 
-import Tabs from "@/widgets/tab/Tabs"; // 새로 분리한 Tab 컴포넌트 가져오기
+import Tabs from "@/widgets/tab/Tabs";
+import Summary from "@/widgets/card/Summary";
+import { Suspense } from "react";
+import { ErrorBoundary } from "next/dist/client/components/error-boundary"; // 새로 분리한 Tab 컴포넌트 가져오기
 
 const AssetManagement: React.FC<{ children: React.ReactNode }> = ({
   children,
@@ -15,6 +18,15 @@ const AssetManagement: React.FC<{ children: React.ReactNode }> = ({
       <div className="header px-[20px]">
         <Tabs items={navItems} />
         {/* timestamp */}
+        <ErrorBoundary
+          errorComponent={({ error }) => (
+            <div>에러가 발생 했습니다.{error.message}</div>
+          )}
+        >
+          <Suspense fallback={<div>로딩중...</div>}>
+            <Summary />
+          </Suspense>
+        </ErrorBoundary>
       </div>
       <div className="content h-[calc(100svh-64px)] min-w-[1080px] overflow-auto bg-gray-5 px-[20px] pt-[20px]">
         {children}

--- a/frontend/src/app/asset-management/overview/page.tsx
+++ b/frontend/src/app/asset-management/overview/page.tsx
@@ -1,19 +1,7 @@
 // pages/asset/overview/page.tsx
-import Summary from "@/widgets/card/Summary";
 
 const Overview = () => {
-  const SUMMARYDATA = [
-    { title: "오늘의 review", type: "review" },
-    { title: "나의 총 자산", type: "amount", amount: 12345600 },
-    { title: "나의 투자 금액", type: "amount", amount: 976294 },
-    { title: "수익금", type: "amount", amount: 1778123 },
-  ];
-
-  return (
-    <div>
-      <Summary summaryData={SUMMARYDATA} />
-    </div>
-  );
+  return <div></div>;
 };
 
 export default Overview;

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -5,6 +5,7 @@ import { Header } from "@/widgets";
 import AuthProvider from "./AuthProvider";
 import JotaiProvider from "./JotaiProvider";
 import { LoginDialog } from "@/features";
+import QueryClientProvider from "@/app/QueryClientProvider";
 
 const inter = Inter({ subsets: ["latin"] });
 
@@ -22,11 +23,13 @@ export default function RootLayout({
       <body className={inter.className}>
         <JotaiProvider>
           <AuthProvider>
-            <div className="relative min-h-svh text-body-1">
-              <Header />
-              {children}
-              <LoginDialog />
-            </div>
+            <QueryClientProvider>
+              <div className="relative min-h-svh text-body-1">
+                <Header />
+                {children}
+                <LoginDialog />
+              </div>
+            </QueryClientProvider>
           </AuthProvider>
         </JotaiProvider>
         <footer className="mx-auto flex h-[84px] max-w-[1400px] items-center justify-between bg-gray-5 px-[20px]">

--- a/frontend/src/shared/constants/api.ts
+++ b/frontend/src/shared/constants/api.ts
@@ -1,2 +1,3 @@
 export const SERVICE_SERVER_URL = "http://api.gaemischool.com:8000";
 export const RESPONSE_STATUS = { BAD_REQUEST: 400, INTERNAL_SERVER_ERROR: 500 };
+export const API_CHART_SUFFIX = "api/chart/v1/sample";

--- a/frontend/src/shared/index.ts
+++ b/frontend/src/shared/index.ts
@@ -5,7 +5,11 @@ export { Heading } from "./ui/layout/src/typography/Heading";
 export { default as LineButton } from "./ui/LineButton";
 export { default as getGoogleOAuth2Client } from "./utils/getGoogleOAuth2Client";
 export { default as setCookieForJWT } from "./utils/setJWTCookie";
-export { SERVICE_SERVER_URL, RESPONSE_STATUS } from "./constants/api";
+export {
+  SERVICE_SERVER_URL,
+  RESPONSE_STATUS,
+  API_CHART_SUFFIX,
+} from "./constants/api";
 export { default as validateTokenExpiry } from "./utils/validateTokenExpiry";
 export { default as SegmentedButton } from "./ui/SegmentedButton";
 export { default as SegmentedButtonGroup } from "./ui/SegmentedButtonGroup";

--- a/frontend/src/shared/lib/query-keys.ts
+++ b/frontend/src/shared/lib/query-keys.ts
@@ -1,3 +1,7 @@
 import { createQueryKeyStore } from "@lukemorales/query-key-factory";
 
-export const keyStore = createQueryKeyStore({});
+export const keyStore = createQueryKeyStore({
+  summary: {
+    getSummary: null,
+  },
+});

--- a/frontend/src/widgets/card/Summary.tsx
+++ b/frontend/src/widgets/card/Summary.tsx
@@ -1,18 +1,42 @@
+"use client";
+
 import SummaryCard from "./SummaryCard";
 
-interface SummaryProps {
-  summaryData: {
-    title: string;
-    type: string;
-    amount?: number;
-  }[];
-}
+import { useGetSummary } from "./queries/useGetSummary";
 
-export default function Summary({ summaryData }: SummaryProps) {
+import { GetSummaryResponse } from "./api/getSummary";
+
+type SummaryDataKey = keyof GetSummaryResponse;
+
+const convertFieldToTitle: Record<SummaryDataKey, string> = {
+  today_review_rate: "오늘의 review",
+  total_asset_amount: "나의 총 자산",
+  total_investment_amount: "나의 투자 금액",
+  profit: "수익금",
+};
+
+export default function Summary() {
+  const { data: summaryData } = useGetSummary();
+
+  const profit = {
+    title: convertFieldToTitle.profit,
+    type: "rate",
+    amount: summaryData.profit.profit_rate,
+  };
+
+  const profitFilteredData = Object.entries(summaryData).filter(
+    ([key]) => key !== "profit",
+  );
+
   return (
     <div className="flex space-x-[16px]">
-      {summaryData.map(({ title, type, amount }) => (
-        <SummaryCard key={title} title={title} type={type} amount={amount} />
+      {profitFilteredData.map(([key, value]) => (
+        <SummaryCard
+          key={key}
+          title={convertFieldToTitle[key]}
+          type={"amount"}
+          amount={value}
+        />
       ))}
     </div>
   );

--- a/frontend/src/widgets/card/SummaryCard.tsx
+++ b/frontend/src/widgets/card/SummaryCard.tsx
@@ -1,5 +1,8 @@
+"use client";
+
 import Card from "@/shared/ui/Card";
 import PriceDisplay from "@/shared/ui/PriceDisplay";
+
 interface SummaryCardProps {
   title?: string;
   type?: string;

--- a/frontend/src/widgets/card/api/getSummary.ts
+++ b/frontend/src/widgets/card/api/getSummary.ts
@@ -1,0 +1,22 @@
+import { SERVICE_SERVER_URL as API_URL } from "@/shared";
+import { API_CHART_SUFFIX } from "@/shared/constants/api";
+
+export interface GetSummaryResponse {
+  today_review_rate: number;
+  total_asset_amount: number;
+  total_investment_amount: number;
+  profit: {
+    profit_amount: number;
+    profit_rate: number;
+  };
+}
+
+export const getSummary = async () => {
+  const response = await fetch(`${API_URL}/${API_CHART_SUFFIX}/summary`);
+
+  if (!response.ok) {
+    throw new Error("요약 데이터를 받아오는데 실패했습니다.");
+  }
+
+  return (await response.json()) as GetSummaryResponse;
+};

--- a/frontend/src/widgets/card/queries/useGetSummary.ts
+++ b/frontend/src/widgets/card/queries/useGetSummary.ts
@@ -1,0 +1,9 @@
+import { useSuspenseQuery } from "@tanstack/react-query";
+import { getSummary } from "@/widgets/card/api/getSummary";
+import { keyStore } from "@/shared/lib/query-keys";
+
+export const useGetSummary = () =>
+  useSuspenseQuery({
+    queryFn: getSummary,
+    queryKey: keyStore.summary.getSummary.queryKey,
+  });


### PR DESCRIPTION
## 스크린샷
<img width="1192" alt="image" src="https://github.com/user-attachments/assets/06fa7ca5-c5cc-4db1-a81b-df8757af3c95">

## 작업 내용
- 상단 요약 API 요청 react query 구현
- Suspense Query, Error Boundary로 에러 및 로딩 UI 구현
- 요약 컴포넌트 위치 page에서 layout으로 수정