### PR TITLE
GROW-95 fix: 요약 상단 페이지 탭바 모바일 반응형 UI 수정

### DIFF
--- a/frontend/src/app/asset-management/layout.tsx
+++ b/frontend/src/app/asset-management/layout.tsx
@@ -11,14 +11,12 @@ const AssetManagement: React.FC<{ children: React.ReactNode }> = ({
   ];
 
   return (
-    <div className="mx-auto w-full max-w-[1400px] flex-1 bg-gray-5 py-[20px]">
-      <div className="header px-[20px]">
-        <Tabs items={navItems} />
-        {/* timestamp */}
-        <Suspense fallback={<div>로딩중...</div>}>
-          <Summary />
-        </Suspense>
-      </div>
+    <div className="mx-auto w-full max-w-[1400px] flex-1 bg-gray-5 px-5">
+      <Tabs items={navItems} />
+      {/* timestamp */}
+      <Suspense fallback={<div>로딩중...</div>}>
+        <Summary />
+      </Suspense>
       <div>{children}</div>
     </div>
   );

--- a/frontend/src/widgets/tab/Tabs.tsx
+++ b/frontend/src/widgets/tab/Tabs.tsx
@@ -11,18 +11,21 @@ const Tabs: React.FC<TabsProps> = ({ items }) => {
   const pathname = usePathname(); // 현재 경로 가져오기
 
   return (
-    <ul className="mb-4 flex space-x-2.5 border-b-[1px] border-[#CDD4DC]">
+    <ul className="my-5 flex flex-row border-b-[1px] border-[#CDD4DC] except-mobile:-mx-5 except-mobile:gap-3 except-mobile:px-5">
       {items.map(({ href, label }) => (
         <Link
           key={href}
           href={href}
-          className={`px-[12px] py-[6px] text-lg ${
+          className={`relative px-1.5 py-3 text-lg mobile:w-full mobile:text-center ${
             pathname === href
-              ? "border-b-[3px] border-black font-bold text-gray-100"
+              ? "font-bold text-gray-100"
               : "font-normal text-gray-60"
           }`}
         >
           <li>{label}</li>
+          {pathname === href && (
+            <hr className="absolute -bottom-[1px] left-0 h-1.5 w-full bg-gray-100" />
+          )}
         </Link>
       ))}
     </ul>


### PR DESCRIPTION
## 스크린샷
### 데스크탑
<img width="1728" alt="스크린샷 2024-10-11 오전 10 16 21" src="https://github.com/user-attachments/assets/99bc3f78-275e-4bc9-8e37-4ea86a59197d">

### 태블릿
<img width="1728" alt="스크린샷 2024-10-11 오전 10 16 27" src="https://github.com/user-attachments/assets/18d5b7ba-e32d-48cc-be83-61a8c510633b">

### 모바일
<img width="1728" alt="스크린샷 2024-10-11 오전 10 16 34" src="https://github.com/user-attachments/assets/8ffb7898-3f95-4912-a92b-1978c9a23c39">

## 작업 내용
- 탭바 반응형 요구사항 정확히 구현되지 않았던 부분들 수정 했습니다.
- border -> hr로 변경한 이유는 border 사용 했을 때 회색 border 위로 검정색 border가 살짝 떠서 보여지던 문제가 있어서 hr 태그 사용하는 방식으로 변경했습니다.