### PR TITLE
GROW-96 design: 자산 적립 추이 섹션 반응형 레이아웃 구현

### DIFF
--- a/frontend/src/app/asset-management/layout.tsx
+++ b/frontend/src/app/asset-management/layout.tsx
@@ -1,18 +1,13 @@
-import Tabs from "@/widgets/tab/Tabs";
+import AssetManagementTabBar from "@/widgets/assets-management-tab-bar/ui/AssetManagementTabBar";
 import { Suspense } from "react";
 import { Summary } from "@/widgets"; // 새로 분리한 Tab 컴포넌트 가져오기
 
 const AssetManagement: React.FC<{ children: React.ReactNode }> = ({
   children,
 }) => {
-  const navItems = [
-    { href: "/asset-management/sheet", label: "시트" },
-    { href: "/asset-management/overview", label: "요약" },
-  ];
-
   return (
     <div className="mx-auto flex w-full max-w-[1400px] flex-1 flex-col gap-4 bg-gray-5 except-mobile:px-5">
-      <Tabs items={navItems} />
+      <AssetManagementTabBar />
       {/* timestamp */}
       <Suspense fallback={<div>로딩중...</div>}>
         <Summary />

--- a/frontend/src/app/asset-management/overview/page.tsx
+++ b/frontend/src/app/asset-management/overview/page.tsx
@@ -1,17 +1,35 @@
 // pages/asset/overview/page.tsx
 
-import { InvestmentPerformanceChart, StockComposition } from "@/widgets";
+import {
+  EstimateDividend,
+  InvestmentPerformanceChart,
+  StockComposition,
+} from "@/widgets";
 import { Suspense } from "react";
 
 const Overview = () => {
   return (
-    <div>
-      <div className="flex flex-col gap-4 except-mobile:flex-row">
-        <Suspense fallback={<div>종목 구성 로딩</div>}>
-          <StockComposition />
+    <div className="flex flex-col gap-4">
+      <div className="grid grid-cols-1 gap-4 except-mobile:grid-cols-5">
+        <div className="col-span-2">
+          <Suspense fallback={<div>종목 구성 로딩</div>}>
+            <StockComposition />
+          </Suspense>
+        </div>
+        <div className="col-span-3">
+          <Suspense fallback={<div>투자 성과 로딩</div>}>
+            <InvestmentPerformanceChart />
+          </Suspense>
+        </div>
+      </div>
+      <div className="grid-cols grid grid-cols-1 gap-4 except-mobile:grid-cols-2">
+        <Suspense fallback={<div>자산 적립 추이 로딩</div>}>
+          <div title="자산 적립 추이">
+            <div>자산 적립 추이 차트 여기</div>
+          </div>
         </Suspense>
-        <Suspense fallback={<div>투자 성과 로딩</div>}>
-          <InvestmentPerformanceChart />
+        <Suspense fallback={<div>예산 배당액 로딩</div>}>
+          <EstimateDividend />
         </Suspense>
       </div>
     </div>

--- a/frontend/src/widgets/assets-management-tab-bar/constants/navItems.ts
+++ b/frontend/src/widgets/assets-management-tab-bar/constants/navItems.ts
@@ -1,0 +1,4 @@
+export const navItems = [
+  { href: "/asset-management/sheet", label: "시트" },
+  { href: "/asset-management/overview", label: "요약" },
+];

--- a/frontend/src/widgets/assets-management-tab-bar/ui/AssetManagementTabBar.tsx
+++ b/frontend/src/widgets/assets-management-tab-bar/ui/AssetManagementTabBar.tsx
@@ -2,17 +2,14 @@
 
 import Link from "next/link";
 import { usePathname } from "next/navigation";
+import { navItems } from "@/widgets/assets-management-tab-bar/constants/navItems";
 
-interface TabsProps {
-  items: { href: string; label: string }[]; // 탭 항목 배열
-}
-
-const Tabs: React.FC<TabsProps> = ({ items }) => {
+const AssetManagementTabBar: React.FC = () => {
   const pathname = usePathname(); // 현재 경로 가져오기
 
   return (
     <ul className="mx-5 my-5 flex flex-row border-b-[1px] border-[#CDD4DC] except-mobile:-mx-5 except-mobile:gap-3 except-mobile:px-5">
-      {items.map(({ href, label }) => (
+      {navItems.map(({ href, label }) => (
         <Link
           key={href}
           href={href}
@@ -32,4 +29,4 @@ const Tabs: React.FC<TabsProps> = ({ items }) => {
   );
 };
 
-export default Tabs;
+export default AssetManagementTabBar;


### PR DESCRIPTION
## 스크린샷

### 데스크탑
<img width="1728" alt="스크린샷 2024-10-11 오후 12 25 26" src="https://github.com/user-attachments/assets/d9db6d31-0195-447d-be6a-cbcd44f15b90">

### 태블릿
<img width="1728" alt="스크린샷 2024-10-11 오전 11 24 45" src="https://github.com/user-attachments/assets/c5997fab-3e50-4a7d-96c8-767f2ffc9b3d">

### 모바일
<img width="1728" alt="스크린샷 2024-10-11 오전 11 24 37" src="https://github.com/user-attachments/assets/dff4272d-0cd9-4c18-aac2-285277033f2b">

## 작업 내용
- 로그인 페이지 useLogin 훅에서 docuement.body.overflow 값을 'hidden'으로 했을 때 모바일 스크린에서 모든 페이지 스크롤이 안되던 문제 수정
- 자산 추이 섹션 반응형 레이아웃 구현